### PR TITLE
Add global account fallback

### DIFF
--- a/admin/js/accounts.js
+++ b/admin/js/accounts.js
@@ -104,6 +104,9 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('sdm-add-account-form').addEventListener('submit', function(e) {
         e.preventDefault();
         var formData = new FormData(this);
+        if (formData.get('project_id') === 'global') {
+            formData.set('project_id', '');
+        }
         formData.append('action', 'sdm_create_sdm_account');
 
         // Собираем данные из динамических полей
@@ -303,6 +306,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     editForm.addEventListener('submit', function(e) {
                         e.preventDefault();
                         var formData = new FormData(this);
+                        if (formData.get('project_id') === 'global') {
+                            formData.set('project_id', '');
+                        }
                         formData.append('action', 'sdm_update_sdm_account');
 
                         // Собираем данные из всех полей формы, включая динамические и пустые, как в форме добавления
@@ -311,7 +317,9 @@ document.addEventListener('DOMContentLoaded', function() {
                         });
 
                         // Добавляем фиксированные поля, включая пустые, как в форме добавления
-                        formData.append('project_id', projectIdHidden.value || '');
+                        var pid = projectIdHidden.value || '';
+                        if (pid === 'global') pid = '';
+                        formData.append('project_id', pid);
                         formData.append('account_id', accountIdHidden.value || '');
                         formData.append('account_name', accountNameInput.value || '');
                         formData.append('email', emailInput.value || '');
@@ -372,8 +380,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 data.data.accounts.forEach(account => {
                     table.innerHTML += `
                         <tr id="account-row-${account.id}" data-account-id="${account.id}" data-update-nonce="${nonce}" data-service="${account.service}">
-                            <td class="column-project-id">${account.project_id}</td>
-                            <td class="column-project-name">${account.project_name || '(No project)'}</td>
+                            <td class="column-project-id">${account.project_id !== null ? account.project_id : '-'}</td>
+                            <td class="column-project-name">${account.project_name || 'Global'}</td>
                             <td class="column-service"><span class="sdm-display-value">${account.service}</span></td>
                             <td class="column-account-name"><span class="sdm-display-value">${account.account_name || ''}</span></td>
                             <td class="column-email"><span class="sdm-display-value">${account.email || ''}</span></td>

--- a/admin/pages/accounts-page.php
+++ b/admin/pages/accounts-page.php
@@ -52,14 +52,14 @@ $main_nonce = sdm_create_main_nonce();
                         data-service="<?php echo esc_attr($account->service); ?>">
                         <!-- Project ID (read-only) -->
                         <td class="column-project-id">
-                            <?php echo esc_html($account->project_id); ?>
+                            <?php echo $account->project_id !== null ? esc_html($account->project_id) : '-'; ?>
                         </td>
 
                         <!-- Project Name (read-only) -->
                         <td class="column-project-name">
                             <?php echo !empty($account->project_name)
                                 ? esc_html($account->project_name)
-                                : esc_html__('(No project)', 'spintax-domain-manager'); ?>
+                                : esc_html__('Global', 'spintax-domain-manager'); ?>
                         </td>
 
                         <!-- Service (read-only) -->
@@ -121,6 +121,7 @@ $main_nonce = sdm_create_main_nonce();
                 <div class="sdm-form-field">
                     <label for="project_id" class="sdm-label"><?php esc_html_e('Project', 'spintax-domain-manager'); ?></label>
                     <select name="project_id" id="project_id" required class="sdm-select">
+                        <option value="global">Global</option>
                         <?php foreach ($all_projects as $proj) : ?>
                             <option value="<?php echo esc_attr($proj->id); ?>">
                                 <?php echo sprintf('%d - %s', $proj->id, $proj->project_name); ?>

--- a/includes/managers/class-sdm-sites-manager.php
+++ b/includes/managers/class-sdm-sites-manager.php
@@ -50,18 +50,8 @@ class SDM_Sites_Manager {
             return false;
         }
 
-        $account = $wpdb->get_row($wpdb->prepare(
-            "SELECT * FROM {$wpdb->prefix}sdm_accounts 
-             WHERE project_id = %d AND service_id = %d LIMIT 1",
-            $project_id,
-            $service->id
-        ));
-
-        if (!$account) {
-            error_log('SDM_Accounts_Manager: Account not found for project_id=' . $project_id . ', service=' . $service_name);
-        }
-
-        return $account;
+        $account_manager = new SDM_Accounts_Manager();
+        return $account_manager->get_account_by_project_and_service($project_id, $service_name);
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow `project_id` field to be NULL
- implement global fallback for accounts
- use account manager in domains/sites managers
- support global accounts in UI and JS

## Testing
- `php` not available, no tests run

------
https://chatgpt.com/codex/tasks/task_e_685333cdddf48325a409efbad9e0c7cf