### PR TITLE
Fix global account fallback

### DIFF
--- a/includes/managers/class-sdm-accounts-manager.php
+++ b/includes/managers/class-sdm-accounts-manager.php
@@ -30,7 +30,7 @@ class SDM_Accounts_Manager {
             $service->id
         ));
 
-        if (!$account && stripos($service_name, 'CloudFlare') === false) {
+        if (!$account) {
             $account = $wpdb->get_row($wpdb->prepare(
                 "SELECT * FROM {$wpdb->prefix}sdm_accounts
                  WHERE project_id IS NULL AND service_id = %d LIMIT 1",


### PR DESCRIPTION
## Summary
- allow accounts manager to retrieve global accounts for all services

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b2a772048325baf520c44eb15dd1