### PR TITLE
Add batch NS sync with progress

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -271,6 +271,21 @@
   border: 1px solid var(--sdm-border);
   border-radius: var(--sdm-border-radius);
 }
+.sdm-progress {
+  width: 100%;
+  height: 20px;
+  background: var(--sdm-bg-th);
+  border: 1px solid var(--sdm-border);
+  border-radius: var(--sdm-border-radius);
+  overflow: hidden;
+  position: relative;
+}
+.sdm-progress-bar {
+  height: 100%;
+  width: 0;
+  background: var(--sdm-accent);
+  transition: width 0.3s ease;
+}
 .sdm-label {
   margin-right: 10px;
   font-weight: 600;

--- a/admin/js/domains-batch.js
+++ b/admin/js/domains-batch.js
@@ -1,0 +1,89 @@
+// Handles batch operations for domains page
+
+document.addEventListener('DOMContentLoaded', function () {
+    var massActionSelect = document.getElementById('sdm-mass-action-select');
+    var massActionApply  = document.getElementById('sdm-mass-action-apply');
+    var mainNonceField   = document.getElementById('sdm-main-nonce');
+    var mainNonce        = mainNonceField ? mainNonceField.value : '';
+    var progressBox      = document.getElementById('sdm-batch-progress');
+    var progressBar      = progressBox ? progressBox.querySelector('.sdm-progress-bar') : null;
+
+    if (!massActionSelect || !massActionApply) return;
+
+    massActionApply.addEventListener('click', function(e){
+        if (massActionSelect.value !== 'sync_ns') return;
+        e.preventDefault();
+
+        var selected = [];
+        document.querySelectorAll('.sdm-domain-checkbox:checked').forEach(function(cb){
+            var row = cb.closest('tr');
+            var isMain = row.querySelector('.sdm-main-domain-icon') !== null;
+            if (!isMain) selected.push(cb.value);
+        });
+
+        if (selected.length === 0) {
+            alert('No domains selected (main domains are excluded).');
+            return;
+        }
+
+        if (!confirm('Sync Cloudflare nameservers to Namecheap for selected domains?')) {
+            return;
+        }
+
+        batchSyncNS(selected.map(function(id){ return parseInt(id); }));
+    });
+
+    function batchSyncNS(domainIds){
+        if (!progressBox || !progressBar) return;
+        var total = domainIds.length;
+        var processed = 0;
+        var batchSize = 10;
+
+        progressBar.style.width = '0%';
+        progressBox.style.display = 'block';
+
+        function doBatch(){
+            if (domainIds.length === 0) {
+                setTimeout(function(){ progressBox.style.display = 'none'; }, 500);
+                if (window.SDM_Domains_API) {
+                    SDM_Domains_API.fetchDomains(
+                        SDM_Domains_API.getCurrentProjectId(),
+                        SDM_Domains_API.getSortColumn(),
+                        SDM_Domains_API.getSortDirection()
+                    );
+                }
+                return;
+            }
+            var batch = domainIds.splice(0, batchSize);
+            Promise.all(batch.map(syncSingle)).then(function(){
+                processed += batch.length;
+                var percent = Math.round(processed / total * 100);
+                progressBar.style.width = percent + '%';
+                doBatch();
+            });
+        }
+
+        function syncSingle(domainId){
+            var fd = new FormData();
+            fd.append('action', 'sdm_sync_cf_ns_namecheap');
+            fd.append('domain_id', domainId);
+            fd.append('sdm_main_nonce_field', mainNonce);
+            return fetch(ajaxurl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: fd
+            }).then(function(r){ return r.json(); })
+              .then(function(resp){
+                  var msg = resp.data || resp.message || 'Unknown server response';
+                  if (!resp.success) {
+                      console.error('Sync error for domain', domainId, msg);
+                  }
+              })
+              .catch(function(err){
+                  console.error('Request failed for domain', domainId, err);
+              });
+        }
+
+        doBatch();
+    }
+});

--- a/admin/js/domains.js
+++ b/admin/js/domains.js
@@ -984,4 +984,13 @@ document.addEventListener('DOMContentLoaded', function () {
             timeout = setTimeout(later, wait);
         };
     }
+
+    // Экспортируем несколько функций и переменных для batch-скриптов
+    window.SDM_Domains_API = {
+        fetchDomains: fetchDomains,
+        showNotice: showDomainsNotice,
+        getCurrentProjectId: () => currentProjectId,
+        getSortColumn: () => lastSortedColumn,
+        getSortDirection: () => sortDirection[lastSortedColumn] || 'desc'
+    };
 });

--- a/admin/pages/domains-page.php
+++ b/admin/pages/domains-page.php
@@ -65,7 +65,7 @@ $main_nonce = sdm_create_main_nonce();
 
     <!-- Project Indicator -->
     <?php if ($current_project_id > 0) : ?>
-        <p class="sdm-project-indicator" style="margin: 10px 0 20px; font-size: 14px; color: #666;">
+        <div class="sdm-project-indicator" style="margin: 10px 0 20px; font-size: 14px; color: #666;">
             <?php
             $project_name = '';
             foreach ($all_projects as $proj) {
@@ -80,7 +80,10 @@ $main_nonce = sdm_create_main_nonce();
                 esc_html($project_name ?: 'Unknown')
             );
             ?>
-        </p>
+            <div id="sdm-batch-progress" class="sdm-progress" style="display:none; margin-top:5px;">
+                <div class="sdm-progress-bar"></div>
+            </div>
+        </div>
     <?php else : ?>
         <p style="margin: 20px 0; color: #666;"><?php esc_html_e('Please select a project to view its domains.', 'spintax-domain-manager'); ?></p>
     <?php endif; ?>

--- a/spintax-domain-manager.php
+++ b/spintax-domain-manager.php
@@ -152,6 +152,13 @@ function sdm_enqueue_admin_assets() {
             SDM_VERSION,
             true
         );
+        wp_enqueue_script(
+            'sdm-domains-batch-js',
+            SDM_PLUGIN_URL . 'admin/js/domains-batch.js',
+            array('jquery', 'sdm-domains-js'),
+            SDM_VERSION,
+            true
+        );
     }
 
     // Подключаем sites.js только на странице сайтов


### PR DESCRIPTION
## Summary
- support batch Sync NS-Servers action on the Domains page
- show progress via a new progress bar
- expose helper functions from domains.js
- load a new JS file for batch operations

## Testing
- `php -v` *(fails: command not found)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686fcc9f23748325988e34c563e88b6e