### PR TITLE
Improve batch NS sync feedback

### DIFF
--- a/admin/js/domains-batch.js
+++ b/admin/js/domains-batch.js
@@ -38,6 +38,8 @@ document.addEventListener('DOMContentLoaded', function () {
         var total = domainIds.length;
         var processed = 0;
         var batchSize = 10;
+        var successCount = 0;
+        var failed = [];
 
         progressBar.style.width = '0%';
         progressBox.style.display = 'block';
@@ -51,6 +53,15 @@ document.addEventListener('DOMContentLoaded', function () {
                         SDM_Domains_API.getSortColumn(),
                         SDM_Domains_API.getSortDirection()
                     );
+                }
+                var msg = successCount + ' domains synced.';
+                if (failed.length) {
+                    msg += ' ' + failed.length + ' failed:\n' + failed.join('\n');
+                    if (window.SDM_Domains_API) {
+                        SDM_Domains_API.showNotice('error', msg);
+                    }
+                } else if (window.SDM_Domains_API) {
+                    SDM_Domains_API.showNotice('updated', msg);
                 }
                 return;
             }
@@ -75,11 +86,14 @@ document.addEventListener('DOMContentLoaded', function () {
             }).then(function(r){ return r.json(); })
               .then(function(resp){
                   var msg = resp.data || resp.message || 'Unknown server response';
-                  if (!resp.success) {
-                      console.error('Sync error for domain', domainId, msg);
+                  if (resp.success) {
+                      successCount++;
+                  } else {
+                      failed.push(domainId + ': ' + msg);
                   }
               })
               .catch(function(err){
+                  failed.push(domainId + ': request failed');
                   console.error('Request failed for domain', domainId, err);
               });
         }

--- a/admin/js/domains.js
+++ b/admin/js/domains.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', function () {
 
     /* ────────── Глобальные переменные ────────── */
+    // SVG-иконка DNS (используется для кнопки Sync NS)
+    var dnsSvgIcon = '<svg width="15" height="18" viewBox="0 0 15 18" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M.078 3.736A3.704 3.704 0 0 1 3.78.031h6.336a3.704 3.704 0 0 1 3.703 3.705V5.9a.924.924 0 0 1-.925.926H1.003A.924.924 0 0 1 .078 5.9zM6.21 9.141c.299 0 .48.338.344.604a5.3 5.30 0 0 0-.575 2.41c0 1.24.332 2.35.792 3.295.125.256-.055.566-.34.566H3.78a3.704 3.704 0 0 1-3.703-3.705v-2.245c0-.51.413-.925.925-.925zm8.091 3.014c0 2.02-1.346 3.679-2.236 4.556a1.08 1.08 0 0 1-1.535 0c-.89-.877-2.236-2.537-2.236-4.556a3.004 3.004 0 1 1 6.007 0" fill="currentColor"/></svg>';
     var mainNonceField  = document.getElementById('sdm-main-nonce');
     var mainNonce       = mainNonceField ? mainNonceField.value : '';
     var projectSelector = document.getElementById('sdm-project-selector');
@@ -124,7 +126,7 @@ document.addEventListener('DOMContentLoaded', function () {
             btn.className = 'button button-small sdm-sync-ns';
             btn.setAttribute('data-domain-id', domainId);
             btn.title = 'Sync NS to Namecheap';
-            btn.innerHTML = '<span class="dashicons dashicons-update"></span>';
+            btn.innerHTML = dnsSvgIcon;
 
             actionsCell.appendChild(btn);
         });


### PR DESCRIPTION
## Summary
- embed dns icon in domains.js and use it for inactive rows
- improve batch Sync NS script to show success/failure counts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fd3d29f2483259d80316c23b70cb3