### PR TITLE
Fix NS sync button output for inactive domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A new AJAX endpoint (`sdm_ajax_get_zone_account_details`) was added to fetch acc
 ## UI & Code Integration
 The new email forwarding functionality was integrated into the existing domain management UI without affecting core features such as sorting, mass actions, and domain deletion.
 
+## Improved NS Sync Buttons
+Inactive domains now display a red "Sync NS" button directly in the domains table without relying on JavaScript manipulation.
+
 ...
 
 ## 2DO

--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -426,6 +426,11 @@ tr[data-site-id="0"] .sdm-target-domain {
   color: var(--sdm-green);
 }
 
+/* Inactive domains - highlight sync button */
+.sdm-sync-ns-inactive {
+  color: var(--sdm-red);
+}
+
 /*--------------------------------------------------------------
 8. MODALS
 --------------------------------------------------------------*/

--- a/admin/js/domains.js
+++ b/admin/js/domains.js
@@ -90,8 +90,6 @@ document.addEventListener('DOMContentLoaded', function () {
             if (data.success) {
                 container.innerHTML = data.data.html;
 
-                appendSyncButtons();        // ← добавляем кнопки после отрисовки таблицы
-
                 initializeDynamicListeners();
                 initializeSorting();
             } else {
@@ -108,29 +106,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
 
-    /* ────────── Вставка кнопок “Sync NS” ────────── */
-    function appendSyncButtons() {
-        // Для всех <tr> с data-domain-id добавляем кнопку, если её ещё нет
-        const rows = document.querySelectorAll('#sdm-domains-container tr[data-domain-id]');
-        rows.forEach(function (row) {
-            if (row.querySelector('.sdm-sync-ns')) return;      // кнопка уже есть
-
-            const domainId = row.getAttribute('data-domain-id');
-            if (!domainId) return;
-
-            // Ищем ячейку действий – класс .sdm-actions или последняя TD
-            let actionsCell = row.querySelector('.sdm-actions');
-            if (!actionsCell) actionsCell = row.lastElementChild;
-
-            const btn = document.createElement('button');
-            btn.className = 'button button-small sdm-sync-ns';
-            btn.setAttribute('data-domain-id', domainId);
-            btn.title = 'Sync NS to Namecheap';
-            btn.innerHTML = dnsSvgIcon;
-
-            actionsCell.appendChild(btn);
-        });
-    }
 
 
 

--- a/includes/managers/class-sdm-domains-manager.php
+++ b/includes/managers/class-sdm-domains-manager.php
@@ -855,7 +855,22 @@ function sdm_ajax_fetch_domains_list() {
                                 <!-- ↑↑ NEW Sync NS -->
 
                             <?php else : ?>
-                                <!-- Delete (неактивные / заблокированные) -->
+                                <!-- Sync NS + Delete for inactive/blocked -->
+                                <button type="button"
+                                        class="sdm-action-button sdm-mini-icon sdm-sync-ns sdm-sync-ns-inactive"
+                                        data-domain-id="<?php echo esc_attr($domain->id); ?>"
+                                        title="<?php esc_attr_e('Sync NS to Namecheap', 'spintax-domain-manager'); ?>">
+                                    <?php
+                                    $dns_svg = file_get_contents(SDM_PLUGIN_DIR . 'assets/icons/dns.svg');
+                                    echo $dns_svg
+                                        ? wp_kses($dns_svg, [
+                                              'svg'=>['width'=>true,'height'=>true,'viewBox'=>true,'fill'=>true,'xmlns'=>true],
+                                              'path'=>['d'=>true,'fill'=>true,'fill-rule'=>true,'clip-rule'=>true],
+                                          ])
+                                        : '<img src="'.esc_url(SDM_PLUGIN_URL.'assets/icons/dns.svg').'" alt="NS" width="16" height="16" />';
+                                    ?>
+                                </button>
+
                                 <button type="button"
                                         class="sdm-action-button sdm-delete-domain sdm-delete sdm-mini-icon"
                                         data-domain-id="<?php echo esc_attr($domain->id); ?>"

--- a/spintax-domain-manager.php
+++ b/spintax-domain-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Spintax Domain Manager
  * Plugin URI:        https://spintax.net/domain_manager
  * Description:       A WordPress plugin for managing domains, redirects, and external API integrations.
- * Version:           1.0.6
+ * Version:           1.0.7
  * Requires at least: 5.8
  * Requires PHP:      7.4
  * Author:            Divisor & ChatGPT
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('SDM_VERSION', '1.0.6');
+define('SDM_VERSION', '1.0.7');
 define('SDM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('SDM_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('SDM_PLUGIN_BASENAME', plugin_basename(__FILE__));


### PR DESCRIPTION
## Summary
- show Sync NS button directly from PHP for inactive domains
- apply red highlight style to inactive sync button
- remove JS code that injected the button dynamically
- bump plugin version to 1.0.7 and update changelog

## Testing
- `node -v`
- *(no other tests were run as the environment lacks PHP)*

------
https://chatgpt.com/codex/tasks/task_e_686fdaf43ed88325a8985be0f6198b8c