### PR TITLE
Switch sdm-sites icons to flags

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -502,15 +502,10 @@ tr[data-site-id="0"] .sdm-target-domain {
   display: inline-block;
   width: 24px;
   height: 24px;
-  cursor: pointer;
   vertical-align: middle;
   overflow: hidden;
   line-height: 0;
   position: relative;
-}
-
-.sdm-site-icon:hover svg {
-  opacity: 0.8;
 }
 tr[data-redirect-type="main"] {
   background-color: #E6F9F0; /* Бледно-зелёный как у Cloudflare */

--- a/admin/js/sites.js
+++ b/admin/js/sites.js
@@ -119,13 +119,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 e.preventDefault();
                 const row = e.target.closest('tr');
                 saveRow(row);
-            } else if (e.target.closest('.sdm-site-icon')) {
-                e.preventDefault();
-                const iconSpan = e.target.closest('.sdm-site-icon');
-                const siteId = iconSpan.getAttribute('data-site-id');
-                if (currentProjectId > 0) {
-                    openIconModal(siteId);
-                }
             }
         });
     }
@@ -280,69 +273,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
-    // Обработка редактирования SVG-иконки
-    const openIconModal = (siteId) => {
-        const modal = document.getElementById('sdm-edit-icon-modal');
-        const siteIdField = document.getElementById('sdm-icon-site-id');
-        const svgInput = document.getElementById('svg_icon');
-        const currentIcon = document.querySelector(`#site-row-${siteId} .sdm-site-icon`).innerHTML.trim();
-        if (modal && siteIdField && svgInput && currentProjectId > 0) {
-            siteIdField.value = siteId;
-            svgInput.value = currentIcon;
-            modal.style.display = 'block';
-        }
-    };
-
-    const editIconForm = document.getElementById('sdm-edit-icon-form');
-    if (editIconForm && currentProjectId > 0) {
-        editIconForm.addEventListener('submit', (e) => {
-            e.preventDefault();
-            const formData = new FormData(editIconForm);
-            let svgIcon = document.getElementById('svg_icon').value;
-            svgIcon = svgIcon.replace(/width="[^"]*"/i, '').replace(/height="[^"]*"/i, '');
-            formData.set('svg_icon', svgIcon);
-            formData.append('action', 'sdm_update_site_icon');
-            formData.append('sdm_main_nonce_field', mainNonce);
-            const submitButton = editIconForm.querySelector('button[type="submit"]');
-            toggleButtonSpinner(submitButton, true);
-            fetch(ajaxurl, {
-                method: 'POST',
-                credentials: 'same-origin',
-                body: formData
-            })
-            .then(response => response.json())
-            .then(data => {
-                toggleButtonSpinner(submitButton, false);
-                if (data.success) {
-                    const siteId = document.getElementById('sdm-icon-site-id').value;
-                    const iconSpan = document.querySelector(`#site-row-${siteId} .sdm-site-icon`);
-                    iconSpan.innerHTML = data.data.svg_icon;
-                    document.getElementById('sdm-edit-icon-modal').style.display = 'none';
-                    showSitesNotice('updated', 'Icon updated successfully.');
-                } else {
-                    showSitesNotice('error', data.data);
-                }
-            })
-            .catch(error => {
-                console.error('Update icon error:', error);
-                toggleButtonSpinner(submitButton, false);
-                showSitesNotice('error', 'Ajax request failed.');
-            });
-        });
-    }
-
-    const closeIconModal = document.getElementById('sdm-close-icon-modal');
-    const iconModalOverlay = document.querySelector('#sdm-edit-icon-modal .sdm-modal-overlay');
-    if (closeIconModal && currentProjectId > 0) {
-        closeIconModal.addEventListener('click', () => {
-            document.getElementById('sdm-edit-icon-modal').style.display = 'none';
-        });
-    }
-    if (iconModalOverlay && currentProjectId > 0) {
-        iconModalOverlay.addEventListener('click', () => {
-            document.getElementById('sdm-edit-icon-modal').style.display = 'none';
-        });
-    }
 
     // Функция для загрузки свободных доменов для select'а
     const fetchNonBlockedDomainsForSelect = (selectElement) => {

--- a/admin/pages/sites-page.php
+++ b/admin/pages/sites-page.php
@@ -109,15 +109,7 @@ $main_nonce = sdm_create_main_nonce();
                     ?>
                     <tr id="site-row-<?php echo esc_attr($site->id); ?>" data-site-id="<?php echo esc_attr($site->id); ?>" data-update-nonce="<?php echo esc_attr($main_nonce); ?>">
                         <td class="column-icon">
-                            <span class="sdm-site-icon" data-site-id="<?php echo esc_attr($site->id); ?>">
-                                <?php 
-                                if (!empty($site->svg_icon)) {
-                                    echo $site->svg_icon;
-                                } else {
-                                    echo file_get_contents(SDM_PLUGIN_DIR . 'assets/icons/spintax-icon.svg');
-                                }
-                                ?>
-                            </span>
+                            <span class="fi fi-<?php echo esc_attr(sdm_normalize_language_code($site->language ?: 'en')); ?>" style="vertical-align: middle;"></span>
                         </td>
                         <td class="column-site-name">
                             <span class="sdm-display-value"><?php echo esc_html($site->site_name); ?></span>
@@ -196,30 +188,6 @@ $main_nonce = sdm_create_main_nonce();
         </tbody>
     </table>
 
-    <!-- Modal for Editing SVG Icon -->
-    <div id="sdm-edit-icon-modal" style="display:none;">
-        <div class="sdm-modal-overlay"></div>
-        <div class="sdm-modal-content">
-            <span id="sdm-close-icon-modal" style="position:absolute; top:10px; right:15px; font-size:20px; cursor:pointer;">×</span>
-            <h2><?php esc_html_e('Edit Site Icon', 'spintax-domain-manager'); ?></h2>
-            <form id="sdm-edit-icon-form" class="sdm-form" method="post" action="">
-                <input type="hidden" name="site_id" id="sdm-icon-site-id">
-                <?php sdm_nonce_field(); ?>
-                <table class="sdm-form-table">
-                    <tr>
-                        <th><label for="svg_icon"><?php esc_html_e('SVG Icon', 'spintax-domain-manager'); ?></label></th>
-                        <td>
-                            <textarea name="svg_icon" id="svg_icon" rows="5" placeholder='<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20"/></svg>'></textarea>
-                            <p class="description"><?php esc_html_e('Paste your inline SVG code here. Recommended size: 24x24px.', 'spintax-domain-manager'); ?></p>
-                        </td>
-                    </tr>
-                </table>
-                <p class="submit">
-                    <button type="submit" class="button button-primary"><?php esc_html_e('Save Icon', 'spintax-domain-manager'); ?></button>
-                </p>
-            </form>
-        </div>
-    </div>
 
     <!-- Form for Adding a New Site -->
     <h2><?php esc_html_e('Add New Site', 'spintax-domain-manager'); ?></h2>


### PR DESCRIPTION
## Summary
- drop SVG icon editing from sites page
- display flag icons based on site language
- remove associated JS code and cursor styling

## Testing
- `php -l admin/pages/sites-page.php`
- `node -e "require('fs').readFileSync('admin/js/sites.js'); console.log('JS loaded');" && echo 'Ok'`

------
https://chatgpt.com/codex/tasks/task_e_68839130376483258ed2328cba03fa00