### PR TITLE
Persist active project selection

### DIFF
--- a/admin/pages/domains-page.php
+++ b/admin/pages/domains-page.php
@@ -20,19 +20,23 @@ $service_manager = new SDM_Service_Types_Manager();
 $services = $service_manager->get_all_services();
 
 // Получаем список сайтов для текущего проекта
-$current_project_id = isset($_GET['project_id']) ? absint($_GET['project_id']) : 0;
-$sites = [];
+$current_project_id = isset($_GET["project_id"]) ? absint($_GET["project_id"]) : sdm_get_active_project_id();
 if ($current_project_id > 0) {
+    sdm_set_active_project_id($current_project_id);
     $sites = $wpdb->get_results(
         $wpdb->prepare("SELECT * FROM {$wpdb->prefix}sdm_sites WHERE project_id = %d", $current_project_id)
     );
+} else {
+    $sites = [];
 }
+
 
 // Генерируем nonce
 $main_nonce = sdm_create_main_nonce();
 ?>
 <div class="wrap">
     <h1><?php esc_html_e('Domains', 'spintax-domain-manager'); ?></h1>
+    <?php sdm_render_project_nav($current_project_id); ?>
 
     <!-- Hidden field for global nonce -->
     <input type="hidden" id="sdm-main-nonce" value="<?php echo esc_attr($main_nonce); ?>">

--- a/admin/pages/redirects-page.php
+++ b/admin/pages/redirects-page.php
@@ -16,14 +16,17 @@ $prefix = $wpdb->prefix;
 $projects_manager = new SDM_Projects_Manager();
 $all_projects = $projects_manager->get_all_projects();
 
-// Текущий проект (через GET)
-$current_project_id = isset($_GET['project_id']) ? absint($_GET['project_id']) : 0;
-
+// Текущий проект
+$current_project_id = isset($_GET['project_id']) ? absint($_GET['project_id']) : sdm_get_active_project_id();
+if ($current_project_id > 0) {
+    sdm_set_active_project_id($current_project_id);
+}
 // Генерируем nonce
 $main_nonce = sdm_create_main_nonce();
 ?>
 <div class="wrap">
     <h1><?php esc_html_e('Redirects', 'spintax-domain-manager'); ?></h1>
+    <?php sdm_render_project_nav($current_project_id); ?>
 
     <!-- Hidden field for global nonce -->
     <input type="hidden" id="sdm-main-nonce" value="<?php echo esc_attr($main_nonce); ?>">

--- a/admin/pages/sites-page.php
+++ b/admin/pages/sites-page.php
@@ -19,8 +19,11 @@ $site_monitoring_enabled = true;
 $projects_manager = new SDM_Projects_Manager();
 $all_projects = $projects_manager->get_all_projects();
 
-// Определяем текущий выбранный проект (через GET)
-$current_project_id = isset($_GET['project_id']) ? absint($_GET['project_id']) : 0;
+// Определяем текущий выбранный проект
+$current_project_id = isset($_GET['project_id']) ? absint($_GET['project_id']) : sdm_get_active_project_id();
+if ($current_project_id > 0) {
+    sdm_set_active_project_id($current_project_id);
+}
 
 // Если проект выбран, получаем сайты этого проекта
 $sites = array();
@@ -55,6 +58,7 @@ $main_nonce = sdm_create_main_nonce();
 ?>
 <div class="wrap">
     <h1><?php esc_html_e('Sites', 'spintax-domain-manager'); ?></h1>
+    <?php sdm_render_project_nav($current_project_id); ?>
 
     <!-- Hidden field for global nonce -->
     <input type="hidden" id="sdm-main-nonce" value="<?php echo esc_attr($main_nonce); ?>">

--- a/includes/common-functions.php
+++ b/includes/common-functions.php
@@ -17,6 +17,37 @@ function sdm_normalize_language_code( $language_code ) {
     return isset( $mappings[$normalized] ) ? $mappings[$normalized] : $normalized;
 }
 
+/**
+ * Get active project ID for current user.
+ */
+function sdm_get_active_project_id() {
+    $id = get_user_meta( get_current_user_id(), 'sdm_active_project_id', true );
+    return $id ? absint( $id ) : 0;
+}
+
+/**
+ * Set active project ID for current user.
+ *
+ * @param int $project_id Project ID.
+ */
+function sdm_set_active_project_id( $project_id ) {
+    update_user_meta( get_current_user_id(), 'sdm_active_project_id', absint( $project_id ) );
+}
+
+/**
+ * Render navigation links for current project pages.
+ *
+ * @param int $project_id Current project ID.
+ */
+function sdm_render_project_nav( $project_id ) {
+    $params = $project_id > 0 ? '&project_id=' . absint( $project_id ) : '';
+    echo '<nav class="sdm-project-nav" style="margin:10px 0;">';
+    echo '<a href="admin.php?page=sdm-sites' . esc_attr( $params ) . '">' . esc_html__( 'Sites', 'spintax-domain-manager' ) . '</a> | ';
+    echo '<a href="admin.php?page=sdm-domains' . esc_attr( $params ) . '">' . esc_html__( 'Domains', 'spintax-domain-manager' ) . '</a> | ';
+    echo '<a href="admin.php?page=sdm-redirects' . esc_attr( $params ) . '">' . esc_html__( 'Redirects', 'spintax-domain-manager' ) . '</a>';
+    echo '</nav>';
+}
+
 if ( ! function_exists( 'sdm_get_server_ip' ) ) {
     /**
      * Возвращает IP-адрес текущего сервера.


### PR DESCRIPTION
## Summary
- track active project for current user
- add project navigation near page titles
- keep project selection when switching pages

## Testing
- `find . -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_688478c63de08325978a337b10c0c76c