### PR TITLE
Update domain table flag position and abuse status highlighting

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -323,6 +323,10 @@
   color: var(--sdm-red) !important;
   font-weight: 600;
 }
+.sdm-abuse-warning {
+  color: var(--sdm-red);
+  font-weight: 600;
+}
 .sdm-no-redirect {
   color: #999;
   font-style: italic;

--- a/includes/managers/class-sdm-domains-manager.php
+++ b/includes/managers/class-sdm-domains-manager.php
@@ -739,22 +739,24 @@ function sdm_ajax_fetch_domains_list() {
                         <!-- Site link / main-icon -------------------------------------------- -->
                         <td>
                             <?php if ($is_assigned) : ?>
+                                <?php if ($is_main_domain) : ?>
+                                    <span class="sdm-main-domain-icon" style="display:inline-flex;align-items:center;margin-right:5px;width:auto;height:auto;font-size:16px;">
+                                        <span class="fi fi-<?php echo esc_attr( sdm_normalize_language_code( $domain->language ?: 'en' ) ); ?>" style="vertical-align:middle;"></span>
+                                    </span>
+                                <?php endif; ?>
                                 <a href="?page=sdm-sites&project_id=<?php echo esc_attr($project_id); ?>"
                                    class="sdm-site-link">
                                     <?php echo esc_html($domain->site_name); ?>
                                 </a>
-                                <?php if ($is_main_domain) : ?>
-                                    <span class="sdm-main-domain-icon" style="display:inline-flex;align-items:center;margin-left:5px;width:auto;height:auto;font-size:16px;">
-                                        <span class="fi fi-<?php echo esc_attr( sdm_normalize_language_code( $domain->language ?: 'en' ) ); ?>" style="vertical-align:middle;"></span>
-                                    </span>
-                                <?php endif; ?>
                             <?php else : ?>
                                 (Unassigned)
                             <?php endif; ?>
                         </td>
 
                         <!-- Other columns ------------------------------------------------------ -->
-                        <td><?php echo esc_html($domain->abuse_status); ?></td>
+                        <td class="<?php echo $domain->abuse_status !== 'clean' ? 'sdm-abuse-warning' : ''; ?>">
+                            <?php echo esc_html($domain->abuse_status); ?>
+                        </td>
                         <td><?php echo $is_blocked ? esc_html__('Yes', 'spintax-domain-manager') : esc_html__('No', 'spintax-domain-manager'); ?></td>
                         <td><?php echo esc_html($domain->status); ?></td>
                         <td><?php echo esc_html($domain->last_checked); ?></td>


### PR DESCRIPTION
## Summary
- show language flag before site name on domain table
- mark non-clean abuse statuses in red

## Testing
- `php -l includes/managers/class-sdm-domains-manager.php`

------
https://chatgpt.com/codex/tasks/task_e_6884dfdcea648325abc1135a8b9b4fb8