### PR TITLE
Fix HostTracker pool mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,8 @@ Copy the plugin folder to your WordPress installation and activate it. Configure
 - Removed underline from project navigation links.
 - Added a server IP selector when adding new sites.
 
+### 1.0.10
+- Updated HostTracker region mapping for languages without dedicated pools.
+
 ### 1.0.8
 - Combined header and navigation into a single line for project pages.

--- a/includes/api/class-sdm-hosttracker-api.php
+++ b/includes/api/class-sdm-hosttracker-api.php
@@ -22,29 +22,27 @@ class SDM_HostTracker_API {
             case 'ru':
                 return array('russia');
             case 'tr':
-                return array('turkey');
+                return array('westeurope');
             case 'cn':
-                return array('china');
+                return array('asia');
             case 'ir':
                 return array('iran');
             case 'sa':
-                return array('saudiarabia');
             case 'ae':
-                return array('uae');
+                return array('asia');
             case 'by':
-                return array('belarus');
+                return array('easteurope');
             case 'kz':
-                return array('kazakhstan');
+                return array('asia');
             case 'en':
-                return array('usa');
+                return array('northamerica');
             case 'es':
-                return array('spain');
             case 'fr':
-                return array('france');
+                return array('westeurope');
             case 'pl':
-                return array('poland');
+                return array('easteurope');
             default:
-                return array('europe');
+                return array('westeurope');
         }
     }
 


### PR DESCRIPTION
## Summary
- map each language code to an existing HostTracker pool
- note change in README

## Testing
- `php -l includes/api/class-sdm-hosttracker-api.php`
- `find . -name '*.php' -print0 | xargs -0 -n 1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6887417a8ea4832591057ba9590fed93