### PR TITLE
Fix HostTracker country pool selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,8 @@ Copy the plugin folder to your WordPress installation and activate it. Configure
 ### 1.0.10
 - Updated HostTracker region mapping for languages without dedicated pools.
 
+### 1.0.11
+- Improved HostTracker pool selection for regional sites, using country-level pools when available.
+
 ### 1.0.8
 - Combined header and navigation into a single line for project pages.

--- a/includes/api/class-sdm-hosttracker-api.php
+++ b/includes/api/class-sdm-hosttracker-api.php
@@ -17,30 +17,43 @@ class SDM_HostTracker_API {
      * @param string $lang Two letter language code (e.g. 'ru').
      * @return array Array of agent pools.
      */
+    private static $available_pools = array(
+        'russia', 'turkey', 'china', 'iran', 'saudiarabia', 'uae',
+        'belarus', 'kazakhstan', 'usa', 'spain', 'france', 'poland',
+        'westeurope', 'easteurope', 'asia', 'northamerica'
+    );
+
+    private static function agent_pool_exists($pool) {
+        return in_array($pool, self::$available_pools, true);
+    }
+
     private static function map_language_to_agent_pools($lang) {
-        switch (strtolower($lang)) {
+        $lang = strtolower($lang);
+        switch ($lang) {
             case 'ru':
                 return array('russia');
             case 'tr':
-                return array('westeurope');
+                return self::agent_pool_exists('turkey') ? array('turkey') : array('easteurope');
             case 'cn':
-                return array('asia');
+                return self::agent_pool_exists('china') ? array('china') : array('asia');
             case 'ir':
                 return array('iran');
             case 'sa':
+                return self::agent_pool_exists('saudiarabia') ? array('saudiarabia') : array('asia');
             case 'ae':
-                return array('asia');
+                return self::agent_pool_exists('uae') ? array('uae') : array('asia');
             case 'by':
-                return array('easteurope');
+                return self::agent_pool_exists('belarus') ? array('belarus') : array('easteurope');
             case 'kz':
-                return array('asia');
+                return self::agent_pool_exists('kazakhstan') ? array('kazakhstan') : array('asia');
             case 'en':
-                return array('northamerica');
+                return self::agent_pool_exists('usa') ? array('usa') : array('northamerica');
             case 'es':
+                return self::agent_pool_exists('spain') ? array('spain') : array('westeurope');
             case 'fr':
-                return array('westeurope');
+                return self::agent_pool_exists('france') ? array('france') : array('westeurope');
             case 'pl':
-                return array('easteurope');
+                return self::agent_pool_exists('poland') ? array('poland') : array('easteurope');
             default:
                 return array('westeurope');
         }

--- a/spintax-domain-manager.php
+++ b/spintax-domain-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Spintax Domain Manager
  * Plugin URI:        https://spintax.net/domain_manager
  * Description:       A WordPress plugin for managing domains, redirects, and external API integrations.
- * Version:           1.0.9
+ * Version:           1.0.11
  * Requires at least: 5.8
  * Requires PHP:      7.4
  * Author:            Divisor & ChatGPT


### PR DESCRIPTION
## Summary
- improve HostTracker agent pool mapping logic
- bump plugin version to 1.0.11
- document pool fix in changelog

## Testing
- `php -l includes/api/class-sdm-hosttracker-api.php`
- `php -l spintax-domain-manager.php`
- `find includes -name '*.php' -print0 | xargs -0 -n1 php -l`
- `find admin -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_688745566160832583aa37e9f64d566e