### PR TITLE
Fix HostTracker region pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,8 @@ Copy the plugin folder to your WordPress installation and activate it. Configure
 ### 1.0.11
 - Improved HostTracker pool selection for regional sites, using country-level pools when available.
 
+### 1.0.12
+- Removed unsupported HostTracker pools and mapped languages to the nearest available regions.
+
 ### 1.0.8
 - Combined header and navigation into a single line for project pages.

--- a/includes/api/class-sdm-hosttracker-api.php
+++ b/includes/api/class-sdm-hosttracker-api.php
@@ -18,9 +18,9 @@ class SDM_HostTracker_API {
      * @return array Array of agent pools.
      */
     private static $available_pools = array(
-        'russia', 'turkey', 'china', 'iran', 'saudiarabia', 'uae',
-        'belarus', 'kazakhstan', 'usa', 'spain', 'france', 'poland',
-        'westeurope', 'easteurope', 'asia', 'northamerica'
+        // Available top-level HostTracker pools as of 2025
+        'africa', 'allworld', 'asia', 'australia', 'easteurope', 'iran',
+        'northamerica', 'russia', 'southamerica', 'waterfall', 'westeurope'
     );
 
     private static function agent_pool_exists($pool) {

--- a/spintax-domain-manager.php
+++ b/spintax-domain-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Spintax Domain Manager
  * Plugin URI:        https://spintax.net/domain_manager
  * Description:       A WordPress plugin for managing domains, redirects, and external API integrations.
- * Version:           1.0.11
+ * Version:           1.0.12
  * Requires at least: 5.8
  * Requires PHP:      7.4
  * Author:            Divisor & ChatGPT


### PR DESCRIPTION
## Summary
- update HostTracker pools list to the currently supported regions
- bump plugin version to 1.0.12
- document changes in changelog

## Testing
- `php -l includes/api/class-sdm-hosttracker-api.php`
- `php -l spintax-domain-manager.php`
- `find . -name '*.php' -print0 | xargs -0 -I {} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_68874a35b6108325a13f36fb74356295