### PR TITLE
Expire missing domains when syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,8 @@ Copy the plugin folder to your WordPress installation and activate it. Configure
 ### 1.0.12
 - Removed unsupported HostTracker pools and mapped languages to the nearest available regions.
 
+### 1.0.13
+- Domains missing from Cloudflare are now marked as expired when syncing.
+
 ### 1.0.8
 - Combined header and navigation into a single line for project pages.


### PR DESCRIPTION
## Summary
- mark missing domains as expired during Cloudflare sync
- note the change in the changelog

## Testing
- `php -l includes/managers/class-sdm-domains-manager.php`
- `php -l spintax-domain-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_68876dc65440832587f76eb8802c2b11