### PR TITLE
Fix HostTracker status updates

### DIFF
--- a/includes/common-functions.php
+++ b/includes/common-functions.php
@@ -99,4 +99,37 @@ if ( ! function_exists( 'sdm_get_server_ip' ) ) {
         return '127.0.0.1';
     }
 }
+
+/**
+ * Determine if HostTracker task state indicates a block.
+ *
+ * @param mixed $state Value of the `lastState` field from HostTracker.
+ * @return bool True if considered blocked, false otherwise.
+ */
+function sdm_hosttracker_state_is_blocked( $state ) {
+    if ( is_bool( $state ) ) {
+        return ! $state; // true => up, false => down
+    }
+
+    if ( is_numeric( $state ) ) {
+        return (int) $state === 0; // 0 => down
+    }
+
+    if ( is_string( $state ) ) {
+        $state_normal = strtolower( trim( $state ) );
+        $up_values   = array( 'up', 'ok', 'true', 'success', 'available' );
+        $down_values = array( 'down', 'blocked', 'false', 'fail', 'failed', 'error' );
+
+        if ( in_array( $state_normal, $up_values, true ) ) {
+            return false;
+        }
+
+        if ( in_array( $state_normal, $down_values, true ) ) {
+            return true;
+        }
+    }
+
+    // Unknown state - treat as not blocked
+    return false;
+}
 ?>

--- a/includes/managers/class-sdm-sites-manager.php
+++ b/includes/managers/class-sdm-sites-manager.php
@@ -532,13 +532,15 @@ class SDM_Sites_Manager {
                 $tasks = SDM_HostTracker_API::get_host_tracker_tasks($token, $type === 'Http' ? 'Http' : 'RusRegBL');
                 foreach ($tasks as $task) {
                     if ($task['id'] === $tid) {
-                        $is_blocked = !$task['lastState'];
+                        $is_blocked = isset( $task['lastState'] ) ? sdm_hosttracker_state_is_blocked( $task['lastState'] ) : false;
+                        $field      = ( $type === 'RusRegBL' ) ? 'is_blocked_government' : 'is_blocked_provider';
+
                         $wpdb->update(
                             $wpdb->prefix . 'sdm_domains',
                             array(
-                                'is_blocked_provider' => ($type === 'RusRegBL') ? ($is_blocked ? 1 : 0) : ($is_blocked ? 0 : 1),
+                                $field        => $is_blocked ? 1 : 0,
                                 'last_checked' => current_time('mysql'),
-                                'updated_at' => current_time('mysql'),
+                                'updated_at'   => current_time('mysql'),
                             ),
                             array('id' => $domain->id),
                             array('%d', '%s', '%s'),


### PR DESCRIPTION
## Summary
- interpret HostTracker task states reliably
- assign status to appropriate blocked field

## Testing
- `php -l includes/common-functions.php`
- `php -l includes/managers/class-sdm-sites-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_688914a3133483259a0e90418ed86435