### PR TITLE
Add Yandex DNS verification via Cloudflare

### DIFF
--- a/admin/pages/sites-page.php
+++ b/admin/pages/sites-page.php
@@ -184,7 +184,7 @@ $main_nonce = sdm_create_main_nonce();
                                     <a href="#" class="sdm-enable-monitoring"><?php esc_html_e('Enable Monitoring', 'spintax-domain-manager'); ?></a>
                                     <hr>
                                     <!-- Если у вас была отдельная кнопка для Яндекса, перенесите её сюда -->
-                                    <a href="#" class="sdm-yandex-webmaster"><?php esc_html_e('Add to Yandex', 'spintax-domain-manager'); ?></a>
+                                    <a href="#" class="sdm-yandex-webmaster" title="<?php esc_attr_e('Verify in Yandex via CloudFlare DNS. Propagation may take a minute.', 'spintax-domain-manager'); ?>"><?php esc_html_e('Add to Yandex', 'spintax-domain-manager'); ?></a>
                                 </div>
                             </div>
                         </td>

--- a/includes/api/class-sdm-cloudflare-api.php
+++ b/includes/api/class-sdm-cloudflare-api.php
@@ -530,6 +530,31 @@ class SDM_Cloudflare_API {
         return new WP_Error( 'zone_not_found', sprintf( __( 'Zone for domain "%s" not found.', 'spintax-domain-manager' ), $domain ) );
     }
 
+    /**
+     * Create a DNS TXT record in a given zone.
+     *
+     * @param string $zone_id Zone identifier.
+     * @param string $name    Record name.
+     * @param string $content TXT content.
+     * @param int    $ttl     TTL in seconds.
+     * @return array|WP_Error
+     */
+    public function create_txt_record( $zone_id, $name, $content, $ttl = 120 ) {
+        $body = array(
+            'type'    => 'TXT',
+            'name'    => $name,
+            'content' => $content,
+            'ttl'     => $ttl,
+        );
+
+        return $this->api_request_extended(
+            "zones/{$zone_id}/dns_records",
+            array(),
+            'POST',
+            $body
+        );
+    }
+
         public function add_zone( $domain ) {
         $url = trailingslashit( $this->endpoint ) . 'zones';
         $headers = array();


### PR DESCRIPTION
## Summary
- add Cloudflare TXT record helper
- wire Yandex DNS verification with asynchronous polling to handle propagation delays
- note propagation delay in Yandex action link

## Testing
- `php -l includes/api/class-sdm-cloudflare-api.php`
- `php -l includes/api/class-sdm-yandex-api.php`
- `php -l includes/managers/class-sdm-sites-manager.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_68a71d6d5a088325b9a8b977fcc8fcd7