### PR TITLE
feat: update Yandex verification with NS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Copy the plugin folder to your WordPress installation and activate it. Configure
 
 ## Changelog
 
+### 1.0.14
+- Added NS-based Yandex verification with automatic Cloudflare NS record creation.
+- Success message now links to Yandex Webmaster for manual confirmation.
+
 ### 1.0.9
 - Removed underline from project navigation links.
 - Added a server IP selector when adding new sites.

--- a/admin/js/sites.js
+++ b/admin/js/sites.js
@@ -425,7 +425,11 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    showSitesNotice('updated', data.data.message);
+                    let msg = data.data.message;
+                    if (data.data.url) {
+                        msg += ' <a href="' + data.data.url + '" target="_blank">Yandex Webmaster</a>';
+                    }
+                    showSitesNotice('updated', msg);
                     pollYandexVerification(siteId, button, 0);
                 } else {
                     toggleButtonSpinner(button, false);

--- a/includes/api/class-sdm-cloudflare-api.php
+++ b/includes/api/class-sdm-cloudflare-api.php
@@ -555,6 +555,42 @@ class SDM_Cloudflare_API {
         );
     }
 
+    /**
+     * Create NS records for delegating a subdomain.
+     *
+     * @param string $zone_id    Zone identifier.
+     * @param string $name       Hostname for the NS record (without zone).
+     * @param array  $nameservers Array of NS servers to assign.
+     * @param int    $ttl        TTL in seconds.
+     * @return array|WP_Error    Array of API responses or WP_Error on failure.
+     */
+    public function create_ns_record( $zone_id, $name, array $nameservers, $ttl = 120 ) {
+        $responses = array();
+        foreach ( $nameservers as $ns ) {
+            $body = array(
+                'type'    => 'NS',
+                'name'    => $name,
+                'content' => $ns,
+                'ttl'     => $ttl,
+            );
+
+            $resp = $this->api_request_extended(
+                "zones/{$zone_id}/dns_records",
+                array(),
+                'POST',
+                $body
+            );
+
+            if ( is_wp_error( $resp ) ) {
+                return $resp;
+            }
+
+            $responses[] = $resp;
+        }
+
+        return $responses;
+    }
+
         public function add_zone( $domain ) {
         $url = trailingslashit( $this->endpoint ) . 'zones';
         $headers = array();

--- a/spintax-domain-manager.php
+++ b/spintax-domain-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Spintax Domain Manager
  * Plugin URI:        https://spintax.net/domain_manager
  * Description:       A WordPress plugin for managing domains, redirects, and external API integrations.
- * Version:           1.0.12
+ * Version:           1.0.14
  * Requires at least: 5.8
  * Requires PHP:      7.4
  * Author:            Divisor & ChatGPT
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('SDM_VERSION', '1.0.9');
+define('SDM_VERSION', '1.0.14');
 define('SDM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('SDM_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('SDM_PLUGIN_BASENAME', plugin_basename(__FILE__));


### PR DESCRIPTION
## Summary
- handle Yandex domain submission with full https URL
- retrieve Yandex-provided NS servers and create matching NS records in Cloudflare
- add manual Yandex Webmaster verification link and bump plugin version

## Testing
- `php -l includes/api/class-sdm-yandex-api.php`
- `php -l includes/api/class-sdm-cloudflare-api.php`
- `php -l includes/managers/class-sdm-sites-manager.php`
- `php -l spintax-domain-manager.php`
- `node --check admin/js/sites.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f355b94832593802513cba94ee1