### PR TITLE
Trigger Yandex DNS verification

### DIFF
--- a/admin/js/sites.js
+++ b/admin/js/sites.js
@@ -430,7 +430,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         msg += ' <a href="' + data.data.url + '" target="_blank">Yandex Webmaster</a>';
                     }
                     showSitesNotice('updated', msg);
-                    pollYandexVerification(siteId, button, 0);
+                    pollYandexVerification(siteId, button, 0, data.data.url);
                 } else {
                     toggleButtonSpinner(button, false);
                     showSitesNotice('error', data.data.message || data.data);
@@ -444,7 +444,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    const pollYandexVerification = (siteId, button, attempt) => {
+    const pollYandexVerification = (siteId, button, attempt, verifyUrl) => {
         setTimeout(() => {
             const fd = new FormData();
             fd.append('action', 'sdm_check_yandex_verification');
@@ -462,12 +462,16 @@ document.addEventListener('DOMContentLoaded', () => {
                     toggleButtonSpinner(button, false);
                     showSitesNotice('updated', 'Yandex verification successful.');
                 } else {
-                    if (attempt < 4) {
+                    if (attempt < 5) {
                         showSitesNotice('updated', 'Waiting for DNS propagation... Checking again soon.');
-                        pollYandexVerification(siteId, button, attempt + 1);
+                        pollYandexVerification(siteId, button, attempt + 1, verifyUrl);
                     } else {
                         toggleButtonSpinner(button, false);
-                        showSitesNotice('error', 'Verification is still pending. Please try again later.');
+                        let msg = 'TXT record created. Please confirm in Yandex Webmaster manually';
+                        if (verifyUrl) {
+                            msg += ' <a href="' + verifyUrl + '" target="_blank">Verify</a>';
+                        }
+                        showSitesNotice('error', msg);
                     }
                 }
             })
@@ -476,7 +480,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 toggleButtonSpinner(button, false);
                 showSitesNotice('error', 'Ajax request failed.');
             });
-        }, 15000);
+        }, 5000);
     };
 
         document.addEventListener('click', (e) => {

--- a/includes/api/class-sdm-cloudflare-api.php
+++ b/includes/api/class-sdm-cloudflare-api.php
@@ -540,6 +540,11 @@ class SDM_Cloudflare_API {
      * @return array|WP_Error
      */
     public function create_txt_record( $zone_id, $name, $content, $ttl = 120 ) {
+        // CloudFlare requires TXT record content to be wrapped in quotes.
+        if ( substr( $content, 0, 1 ) !== '"' ) {
+            $content = '"' . $content . '"';
+        }
+
         $body = array(
             'type'    => 'TXT',
             'name'    => $name,

--- a/includes/api/class-sdm-yandex-api.php
+++ b/includes/api/class-sdm-yandex-api.php
@@ -198,6 +198,37 @@ class SDM_Yandex_API {
     }
 
     /**
+     * Trigger DNS verification for a domain after the record is created.
+     *
+     * @param string $token
+     * @param string $user_id
+     * @param string $domain
+     * @return bool
+     */
+    public static function trigger_verification($token, $user_id, $domain, $type = 'DNS') {
+        $host_id = self::get_host_id($token, $user_id, $domain);
+        if (!$host_id) {
+            return false;
+        }
+
+        $url = "https://api.webmaster.yandex.net/v4/user/$user_id/hosts/$host_id/verification?verification_type=$type";
+        $response = wp_remote_post($url, array(
+            'headers' => array(
+                'Authorization' => 'OAuth ' . $token,
+                'Content-Type'  => 'application/json',
+            ),
+            'timeout' => 25,
+        ));
+
+        if (is_wp_error($response)) {
+            error_log("Error triggering verification for $domain: " . $response->get_error_message());
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Check verification status for a domain in Yandex.Webmaster.
      *
      * @param string $token

--- a/includes/managers/class-sdm-sites-manager.php
+++ b/includes/managers/class-sdm-sites-manager.php
@@ -966,6 +966,9 @@ function sdm_ajax_add_site_to_yandex() {
         wp_send_json_error($dns_resp->get_error_message());
     }
 
+    // After the TXT/NS record is created, trigger DNS verification.
+    SDM_Yandex_API::trigger_verification($token, $user_id, $site->main_domain);
+
     $verify_url = 'https://webmaster.yandex.ru/site/?host=' . rawurlencode('https://' . $site->main_domain . '/');
 
     wp_send_json_success(array(


### PR DESCRIPTION
## Summary
- Ensure CloudFlare TXT records are wrapped in quotes
- Trigger Yandex DNS verification after adding TXT/NS record and prompt manual confirmation
- Poll Yandex verification every 5s and direct user to confirm in Yandex Webmaster if still pending

## Testing
- `php -l includes/api/class-sdm-cloudflare-api.php`
- `php -l includes/api/class-sdm-yandex-api.php`
- `php -l includes/managers/class-sdm-sites-manager.php`
- `node --check admin/js/sites.js`


------
https://chatgpt.com/codex/tasks/task_e_68b05a1224308325a8a2b88b19d421d4