### PR TITLE
Encrypt email forwarding passwords and reorganize admin tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## v1.0.19
+- Added encryption for email forwarding passwords.
+- Added domain grouping by Cloudflare zone in admin UI.
+- Split redirect interface into Main / Glue / Hidden sections.
+- Fixed subdomain detection logic.
+- Added support for multi-component TLDs (example.co.uk, example.com.br).
+- Added automatic DB migration for missing fields (is_subdomain, hosttracker_task_id).
+- Improved handling of Cloudflare DNS placeholder records.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,34 @@ A WordPress plugin that manages domains and related services from a single dashb
 - Bulk actions for assigning sites, syncing statuses and setting abuse or block flags.
 - AJAX powered tables with search, sorting and progress bars.
 - Optional GraphQL integration.
+- Admin UI grouping by Cloudflare zone with clearer root/subdomain context.
+- Support for multi-component TLDs such as `.co.uk`, `.com.br`, and `.com.au` when determining root domains.
 
 ## Installation
 
 Copy the plugin folder to your WordPress installation and activate it. Configure your service accounts under **Spintax Manager → Accounts** to begin managing projects and domains.
+
+## Subdomain Handling
+
+- Root domains and subdomains are detected using Cloudflare zone data (including multi-component TLDs like `example.co.uk`).
+- The plugin sets the `is_subdomain` flag automatically and provisions placeholder DNS `A` records for subdomains when needed.
+- Domain tables in the admin are grouped by Cloudflare zone so root domains and their subdomains stay together.
+
+## Cloudflare Zones
+
+- Domains are synced per project and rendered by zone in the admin interface.
+- Each zone groups its root domain first, followed by indented subdomains with a `sub` badge for clarity.
+- Redirects are separated into Main, Glue, and Hidden sections for easier review before syncing to Cloudflare.
+
+## Security Note
+
+- Email forwarding passwords stored in `wp_sdm_email_forwarding` are encrypted using `sdm_encrypt`/`sdm_decrypt` before saving or using them with external services.
+
+## Requirements
+
+- WordPress 5.8+ and PHP 7.4+.
+- JSON extension enabled on the server (required for API payload handling).
+- Access to Cloudflare, Namecheap, Mail‑in‑a‑Box, HostTracker, or other configured services as needed.
 
 ## Changelog
 

--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -54,6 +54,67 @@
   background-color: var(--sdm-bg-tr-hover);
   transition: background-color 0.2s ease;
 }
+.sdm-zone-row td {
+  background: #f5f7fb;
+  font-weight: 600;
+  border-top: 1px solid var(--sdm-border);
+}
+.sdm-zone-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #1f2933;
+}
+.sdm-root-domain {
+  font-weight: 600;
+}
+.sdm-root-icon {
+  display: inline-block;
+  margin-right: 6px;
+}
+.sdm-subdomain-indent {
+  display: inline-block;
+  margin-right: 8px;
+  color: #9aa3af;
+}
+.sdm-subdomain-label {
+  color: #3c4043;
+}
+.sdm-badge-sub {
+  margin-left: 8px;
+  padding: 2px 6px;
+  font-size: 11px;
+  background: #e8effc;
+  border-radius: 4px;
+  color: #2b5fb3;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+.sdm-status-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.sdm-status-active {
+  background: #e6f6ed;
+  color: #1a7f3b;
+}
+.sdm-status-expired {
+  background: #fff2e6;
+  color: #c05621;
+}
+.sdm-status-available,
+.sdm-status-clean {
+  background: #eef2ff;
+  color: #3f51b5;
+}
+.sdm-status-unknown {
+  background: #f1f1f1;
+  color: #555;
+}
 .sdm-sortable {
   position: relative;
 }

--- a/admin/js/redirects.js
+++ b/admin/js/redirects.js
@@ -532,6 +532,15 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
 
+        document.querySelectorAll('.sdm-toggle-hidden-redirects').forEach(toggle => {
+            const siteId = toggle.getAttribute('data-site-id');
+            toggle.addEventListener('change', function() {
+                document.querySelectorAll(`.sdm-hidden-redirects[data-site-id="${siteId}"]`).forEach(section => {
+                    section.style.display = this.checked ? 'block' : 'none';
+                });
+            });
+        });
+
         document.body.addEventListener('click', (e) => {
             const typeDisplay = e.target.closest('.sdm-redirect-type-display');
             if (typeDisplay) {

--- a/spintax-domain-manager.php
+++ b/spintax-domain-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Spintax Domain Manager
  * Plugin URI:        https://spintax.net/domain_manager
  * Description:       Manage domains, subdomains, redirects, and service integrations from one dashboard.
- * Version:           1.0.18
+ * Version:           1.0.19
  * Requires at least: 5.8
  * Requires PHP:      7.4
  * Author:            Divisor & ChatGPT
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('SDM_VERSION', '1.0.18');
+define('SDM_VERSION', '1.0.19');
 define('SDM_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('SDM_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('SDM_PLUGIN_BASENAME', plugin_basename(__FILE__));


### PR DESCRIPTION
## Summary
- encrypt Mail-in-a-Box mailbox passwords before storing them and reuse decrypted values when updating forwarding records
- group domains by Cloudflare zone in the domains table with clear root and subdomain styling
- split the redirects UI into separate Main, Glue, and Hidden sections with an optional toggle for hidden entries, and document the updates

## Testing
- php -l includes/managers/class-sdm-domains-manager.php
- php -l includes/managers/class-sdm-redirects-manager.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692600829964832581abf4fe5c1219eb)